### PR TITLE
Error handling propogation

### DIFF
--- a/src/request_errors.ts
+++ b/src/request_errors.ts
@@ -1,0 +1,20 @@
+export class EAAccountError extends Error {
+    constructor(message: string) {
+        super(message)
+        this.name = "EAAccountError"
+    }
+}
+
+export class UserDBError extends Error {
+    constructor(message: string) {
+        super(message)
+        this.name = "UserDBError"
+    }
+}
+
+export class InvalidRequestError extends Error {
+    constructor(message: string) {
+        super(message)
+        this.name = "InvalidRequestError"
+    }
+}


### PR DESCRIPTION
Create new error types so we can handle them individually. This means we can send more specific responses back, and make clear what errors are on the caller, on EA, or a internal server Error. 

caller: 400 status code
EA: 500 status code, messages note its from EA
other: 500 status code, exception message